### PR TITLE
Fixed visualizer bug.

### DIFF
--- a/fast3r/viz/viser_visualizer.py
+++ b/fast3r/viz/viser_visualizer.py
@@ -256,9 +256,9 @@ def start_visualization(output, min_conf_thr_percentile=10, global_conf_thr_valu
         img_rgb_orig = to_numpy(view['img'].cpu().squeeze().permute(1,2,0))
         not_sky_mask = detect_sky_mask(img_rgb_orig).flatten().astype(np.int8)
 
-        pts3d_global = to_numpy(pred['pts3d_in_other_view'].cpu().squeeze()).reshape(-1, 3)
+        pts3d_global = to_numpy(pred['pts3d_local_aligned_to_global'].cpu().squeeze()).reshape(-1, 3)
         conf_global = to_numpy(pred['conf'].cpu().squeeze()).flatten()
-        pts3d_local = to_numpy(pred['pts3d_local_aligned_to_global'].cpu().squeeze()).reshape(-1, 3)
+        pts3d_local = to_numpy(pred['pts3d_in_other_view'].cpu().squeeze()).reshape(-1, 3)
         conf_local = to_numpy(pred['conf_local'].cpu().squeeze()).flatten()
         img_rgb = to_numpy(view['img'].cpu().squeeze().permute(1,2,0))
         img_rgb_flat = img_rgb.reshape(-1, 3)


### PR DESCRIPTION
Hi Jianing, 

I found a bug in the visualizer that displays the aligned point cloud as a local frame and the unaligned point cloud as a global frame. "pts3d_local_aligned_to_global" should be the global frame.

However, I noticed that the alignment process seems to have degraded the quality of the point cloud. It seems that the ICP method used in "align_local_pts3d_to_global" has not performed as well as anticipated. 


![YRDXV@62RH%N~F{TW%(KFVF](https://github.com/user-attachments/assets/eb2f57b6-97c8-48ee-878b-2af6fb651113)

Here is my test code.

```python
device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

# Paper data
video = "redkitchen/redkitchen.mp4"
temp_dir = "temp_dir"

frame_paths = extract_frames_from_video(video, temp_dir)

imgs = load_images(frame_paths, size=224)

# Load the model from Hugging Face
model = Fast3R.from_pretrained("jedyang97/Fast3R_ViT_Large_512")
model = model.to(device)

# [Optional] Create a lightweight lightning module wrapper for the model.
# This provides functions to estimate camera poses, evaluate 3D reconstruction, etc.
# See fast3r/viz/demo.py for an example.
lit_module = MultiViewDUSt3RLitModule.load_for_inference(model)

# Set model to evaluation mode
model.eval()
lit_module.eval()

# Run inference directly
output_dict, profiling_info = inference(
    imgs, model, device=device, dtype=torch.float32, verbose=True, profiling=True
)
"""
'pts3d_in_other_view'
'pts3d_local'
'conf_local'
'conf'
'pts3d_local_aligned_to_global'
"""
export_combined_ply(output_dict['preds'], output_dict['views'], 'unaligned.ply', pts3d_key_to_visualize='pts3d_in_other_view', conf_key_to_visualize='conf_local', min_conf_thr_percentile=10)


# Align points
lit_module.align_local_pts3d_to_global(
    preds=output_dict['preds'],
    views=output_dict['views'],
    min_conf_thr_percentile=85
)

export_combined_ply(output_dict['preds'], output_dict['views'], 'aligned.ply', pts3d_key_to_visualize='pts3d_local_aligned_to_global', conf_key_to_visualize='conf', min_conf_thr_percentile=10)
```