### PR TITLE
fix init transform from str

### DIFF
--- a/fast3r/dust3r/datasets/base/base_stereo_view_dataset.py
+++ b/fast3r/dust3r/datasets/base/base_stereo_view_dataset.py
@@ -45,10 +45,10 @@ class BaseStereoViewDataset(EasyDataset):
         self.split = split
         self._set_resolutions(resolution)
 
-        self.transform = transform
         if isinstance(transform, str):
             transform = eval(transform)
-
+        self.transform = transform
+        
         self.aug_crop = aug_crop
         self.seed = seed
 


### PR DESCRIPTION
The PR fixes incorrect initialization order when `transform` is a `string` in `fast3r/dust3r/datasets/base/base_stereo_view_dataset.py`.

As in  [this PR](https://github.com/naver/dust3r/pull/218) in Dust3R.